### PR TITLE
Travis: build only PRs and pushes to master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ env:
 os:
   - linux
   - osx
+branches:
+  only: 
+    - master


### PR DESCRIPTION
Configure Travis to build PR branches and the `master` branch but not other branches in this repository.

Without this change, each PR from a branch in this repository runs two sets of Travis jobs, one for the PR and one for pushes to the branch.